### PR TITLE
add: make installable via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "medienbaecker/likes",
+  "version": "1.0.0",
+  "description": "Kirby Likes adds routes, handy page methods and a panel field so you can easily add likes/hearts/votes to pages.",
+  "type": "kirby-plugin",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Thomas Günther",
+      "email": "mail@medienbaecker.com"
+    }
+  ],
+  "require": {
+    "getkirby/composer-installer": "^1.1"
+  }
+}


### PR DESCRIPTION
This should make the plugin installable via composer on the CLI. It also has to be registered here: https://packagist.org/ 

Because of that, I couldn't test it. But it would be cool if it was available via CLI.